### PR TITLE
#60: Client-side collection switching (no full page reload)

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -55,6 +55,14 @@ The hub entry point. Fetches `cards.json` and renders a card for each game.
 - Dropdown populated from `themes.js` with 10 platform themes
 - Theme selection persisted in `localStorage` key `ifhub-theme`
 
+**Collections:**
+- A Collection dropdown (populated from `hubs.json`) filters the catalog to a curated subset (by engine or tag)
+- The active collection is encoded in the URL query string as `?hub=<id>` (the "all" collection uses the bare path), so a filtered view is shareable and bookmarkable
+- Changing the collection updates the URL via `history.pushState` and re-renders the cards **in place** — no full page reload, since `cards.json`/`hubs.json` are already in memory
+- Browser back/forward (`popstate`) restores the collection encoded in the URL
+- When a non-"all" collection is active, the page title and subtitle are replaced with the collection's `title`/`description`
+- Deep links (`index.html?hub=<id>`) load the filtered view directly
+
 **Static content sections:**
 - "What's Inside" — feature list (play, source, walkthroughs, audio, resizable layout)
 - "About" — project description and philosophy
@@ -66,6 +74,7 @@ The primary play interface. A two-pane layout with the game on the left and sour
 
 **URL parameters:**
 - `?game=<id>` — loads the specified game on startup (defaults to first game in registry)
+- `?hub=<id>` — restricts the game selector to a collection from `hubs.json` (defaults to all games)
 
 **Layout:**
 - CSS Grid with three columns: game pane, resize handle (5px), source pane
@@ -75,6 +84,7 @@ The primary play interface. A two-pane layout with the game on the left and sour
 
 **Toolbar (top, spans full width):**
 - Library link (always visible, returns to `index.html`; uses hub-filtered URL when `hub` param is active)
+- Collection selector dropdown (populated from `hubs.json`): re-filters the game selector **in place** — no page reload. Uses `history.replaceState` to keep the `?hub=` URL shareable without competing with the player iframe's session history. The currently-loaded game stays loaded if it belongs to the new collection; otherwise the first game in the collection loads
 - Game selector dropdown (populated from `games.json`)
 - Style dropdown (overlay-aware theme selector): for games with `overlayLabel`, shows the game's native overlay as the default first option, then a separator, then all platform themes; for games without overlays, shows only platform themes. Per-game style preference stored in `localStorage` key `ifhub-style-<gameId>`
 - Sound controls (mute button + volume slider) — hidden by default, shown when game iframe reports `ifhub:soundReady`

--- a/reference/project-guide.md
+++ b/reference/project-guide.md
@@ -312,8 +312,11 @@ The hub supports curated collections via query-param filtering. A game can belon
 - `cards.json` / `games.json` — Each entry has `engine` (string) and `tags` (string array)
 
 **How it works:**
-- `index.html` and `app.html` fetch `hubs.json`, parse `?hub=X`, and filter games
-- Hub links are `<a href="?hub=X">` — statically shareable URLs
+- `index.html` and `app.html` fetch `hubs.json`, parse `?hub=X` from the URL, and filter games
+- A Collection `<select>` switches collections **client-side** — no full page reload:
+  - `index.html` uses `history.pushState` and re-renders the cards from the in-memory `cards.json`; browser back/forward (`popstate`) restores the collection from the URL
+  - `app.html` uses `history.replaceState` and re-filters the game selector in place (keeping the loaded game if it survives the filter). It uses replace, not push, because the player iframe injects its own session-history entries
+- `?hub=X` URLs remain directly shareable/bookmarkable as deep links
 - Play buttons pass `&hub=X` to `app.html` to maintain the filtered context
 
 **Adding a new hub:** Edit `hubs.json`:

--- a/site/app.html
+++ b/site/app.html
@@ -754,20 +754,27 @@ document.addEventListener('DOMContentLoaded', function() {
     fetch('games.json').then(function(r) { return r.json(); }).catch(function() { console.error('Failed to load games.json'); return []; }),
     fetch('hubs.json').then(function(r) { return r.json(); }).catch(function() { return []; })
   ]).then(function(results) {
-    var data = results[0];
+    var allGames = results[0];
     var hubs = results[1];
 
-    var hubResult = resolveHub(hubs);
-    var activeHub = hubResult.activeHub;
-
-    // Filter games by hub
-    if (activeHub) {
-      data = data.filter(function(g) { return matchesHub(g, activeHub); });
+    // Filter the game list to the hub encoded in the current URL.
+    function applyHubFilter() {
+      var activeHub = resolveHub(hubs).activeHub;
+      games = activeHub
+        ? allGames.filter(function(g) { return matchesHub(g, activeHub); })
+        : allGames.slice();
+      games.sort(function(a, b) { return a.title.localeCompare(b.title); });
+      gameMap = {};
+      games.forEach(function(g) { gameMap[g.id] = g; });
+      return activeHub;
     }
 
-    games = data;
-    games.sort(function(a, b) { return a.title.localeCompare(b.title); });
-    games.forEach(function(g) { gameMap[g.id] = g; });
+    function updateLibraryLink(activeHub) {
+      document.getElementById('library-link').href =
+        (activeHub && activeHub.id !== 'all') ? 'index.html?hub=' + activeHub.id : 'index.html';
+    }
+
+    var activeHub = applyHubFilter();
     buildDropdown();
     bindUI();
     initSoundControls();
@@ -781,15 +788,29 @@ document.addEventListener('DOMContentLoaded', function() {
       hubSelect.appendChild(opt);
     });
     hubSelect.value = activeHub ? activeHub.id : 'all';
+
+    // Collection change: re-filter the game list in place, no page reload.
+    // Keep the current game loaded if it still belongs to the new collection,
+    // otherwise fall back to the first game in the new collection.
+    //
+    // Uses replaceState (not pushState): the player iframe (Parchment) injects
+    // its own session-history entries, so top-level pushState back/forward is
+    // unreliable here. replaceState keeps the URL shareable without competing
+    // with the iframe's history; browser Back then returns to the prior page.
     hubSelect.addEventListener('change', function() {
       var v = hubSelect.value;
-      var url = 'app.html' + (v && v !== 'all' ? '?hub=' + v : '');
-      window.location.href = url;
+      history.replaceState(null, '', 'app.html' + (v && v !== 'all' ? '?hub=' + v : ''));
+      var ah = applyHubFilter();
+      buildDropdown();
+      updateLibraryLink(ah);
+      if (gameMap[currentGame]) {
+        document.getElementById('game-select').value = currentGame;
+      } else if (games.length) {
+        switchGame(games[0].id);
+      }
     });
-    // Update Library link to match hub
-    if (activeHub && activeHub.id !== 'all') {
-      document.getElementById('library-link').href = 'index.html?hub=' + activeHub.id;
-    }
+
+    updateLibraryLink(activeHub);
 
     buildStyleDropdown(null);
 
@@ -807,6 +828,7 @@ document.addEventListener('DOMContentLoaded', function() {
    ================================================================== */
 function buildDropdown() {
   var sel = document.getElementById('game-select');
+  sel.innerHTML = '';
   games.forEach(function(g) {
     var opt = document.createElement('option');
     opt.value = g.id;

--- a/site/index.html
+++ b/site/index.html
@@ -263,30 +263,30 @@ Promise.all([
   var cards = results[0];
   var hubs = results[1];
 
-  var hubResult = resolveHub(hubs);
-  var activeHub = hubResult.activeHub || hubs[0]; // default: first hub ("all")
-
-  // Populate collection dropdown
   var collectionSelect = document.getElementById('collection-select');
+  var container = document.getElementById('games');
+  var titleEl = document.getElementById('hub-title');
+  var subtitleEl = document.getElementById('hub-subtitle');
+  var defaultTitle = titleEl.textContent;
+  var defaultSubtitle = subtitleEl.textContent;
+
+  // Populate collection dropdown once
   hubs.forEach(function(h) {
     var opt = document.createElement('option');
     opt.value = h.id;
     opt.textContent = h.title;
-    if (h.id === activeHub.id) opt.selected = true;
     collectionSelect.appendChild(opt);
   });
 
-  // Collection change navigates to filtered view
+  // Collection change: update URL + re-render in place, no page reload
   collectionSelect.addEventListener('change', function() {
     var id = this.value;
-    window.location.href = id === 'all' ? '.' : '?hub=' + id;
+    history.pushState({ hub: id }, '', id === 'all' ? location.pathname : '?hub=' + id);
+    render();
   });
 
-  // Update title/subtitle when a hub filter is active
-  if (activeHub.id !== 'all') {
-    document.getElementById('hub-title').textContent = activeHub.title;
-    document.getElementById('hub-subtitle').textContent = activeHub.description;
-  }
+  // Back/forward restores the collection encoded in the URL
+  window.addEventListener('popstate', render);
 
   // Wire up theme dropdown (element already exists in HTML)
   var themeSelect = document.getElementById('theme-select');
@@ -298,7 +298,21 @@ Promise.all([
     applyChrome(getTheme(id));
   });
 
-  var container = document.getElementById('games');
+  // Render the catalog for whichever collection the current URL selects.
+  function render() {
+  var activeHub = resolveHub(hubs).activeHub || hubs[0]; // default: first hub ("all")
+  collectionSelect.value = activeHub.id;
+
+  // Title/subtitle reflect the active collection
+  if (activeHub.id !== 'all') {
+    titleEl.textContent = activeHub.title;
+    subtitleEl.textContent = activeHub.description;
+  } else {
+    titleEl.textContent = defaultTitle;
+    subtitleEl.textContent = defaultSubtitle;
+  }
+
+  container.innerHTML = '';
   var filtered = cards.filter(function(card) { return matchesHub(card, activeHub); });
   filtered.sort(function(a, b) { return a.title.localeCompare(b.title); });
 
@@ -393,6 +407,9 @@ Promise.all([
       }
     });
   });
+  }
+
+  render();
 });
 </script>
 


### PR DESCRIPTION
Fixes #60.

## What changed

Switching IF Hub collections used to do a full page reload (`window.location.href = '?hub=' + id`), re-fetching `cards.json`/`games.json`/`hubs.json`/`themes.js` even though all data was already in memory. This makes collection switching client-side while keeping `?hub=<id>` URLs shareable and bookmarkable.

**`site/index.html` (landing page)**
- Card rendering extracted into a reusable `render()` driven by the URL.
- Collection dropdown → `history.pushState` + in-place re-render (no reload).
- `popstate` listener restores the collection on browser back/forward.
- Title/subtitle track the active collection; defaults restored for "All Games".
- Deep links (`?hub=zork`) still load directly.

**`site/app.html` (split-pane player)**
- Hub selector re-filters the game dropdown in place via `history.replaceState`.
- The loaded game **stays loaded** when it survives the filter (no needless Parchment VM reload); otherwise the first game in the collection loads.
- `replaceState` (not `pushState`) is used deliberately: the player iframe (Parchment) injects its own session-history entries, so top-level `pushState` back/forward is unreliable here. `replaceState` keeps the URL shareable without competing with the iframe's history, and browser Back returns to the prior page.

**Docs**
- `docs/functional-spec.md`: new Collections subsection (landing), app.html toolbar + URL params.
- `reference/project-guide.md`: updated Hub Collections "How it works".

## Verification (DOM-inspected via dev server)

index.html:
- Initial render 22 cards / "all"; deep link `?hub=zork` loads filtered.
- Collection switch: no reload (in-page sentinel survived), URL + cards + title update.
- Back/forward faithfully restores each collection.
- Versioned cards render; changing version rebuilds the action dropdown.

app.html:
- Deep link `?hub=sharpee&game=dungeo` loads filtered + correct game.
- Switch to "all": DUNGEON stays loaded, **zero** new history entries, library link updates.
- Switch to "inform7" (DUNGEON absent): swaps to first I7 game.
- No console errors on either page.

## Note for reviewer (Verify column)

Worth a manual pass with the real browser Back/Forward buttons on both pages, and a check that switching collections feels instant. Per the project rule, I can't QA my own work — leaving the Verify step to a human.